### PR TITLE
Skip whitespaces in the beginning of array parsing

### DIFF
--- a/json-parser.el
+++ b/json-parser.el
@@ -51,6 +51,7 @@ nil otherwise."
 		(array-end "]")
 		(parsed-array '()))
 	(skip-chars-forward array-begin)
+	(skip-whitespaces)
 	(while (not (string= (peek) array-end))
 	  (if (string= (peek) ",")
 		  (progn


### PR DESCRIPTION
This avoids the first element of parsed array to be nil